### PR TITLE
Update scripts to assign chyf as owner for new schema and tables when loading workunits

### DIFF
--- a/cabd-database/chyf/nhn_data_processing/nhn_data_load.py
+++ b/cabd-database/chyf/nhn_data_processing/nhn_data_load.py
@@ -4,7 +4,7 @@ import subprocess
 import os
 from nhn_data_qa import run_qa
 
-ogr = "C:\\Program Files\\QGIS 3.12\\bin\\ogr2ogr.exe";
+ogr = "C:\\OSGeo4W64\\bin\\ogr2ogr.exe";
 
 
 if len(sys.argv) != 8:
@@ -247,6 +247,14 @@ where e.geometry && b.geometry and
 
 UPDATE {workingSchema}.terminal_node set aoi_id = (SELECT id from {workingSchema}.aoi);
 UPDATE {workingSchema}.terminal_node set geometry = st_snaptogrid(geometry, {snaptogrid});
+
+ALTER SCHEMA {workingSchema} OWNER TO chyf;
+ALTER TABLE {workingSchema}.aoi OWNER TO chyf;
+ALTER TABLE {workingSchema}.delimiter OWNER TO chyf;
+ALTER TABLE {workingSchema}.ecatchment OWNER TO chyf;
+ALTER TABLE {workingSchema}.eflowpath OWNER TO chyf;
+ALTER TABLE {workingSchema}.shoreline OWNER TO chyf;
+ALTER TABLE {workingSchema}.terminal_node OWNER TO chyf;
 
 """
 log(query)

--- a/cabd-database/chyf/nhn_data_processing/nhn_data_qa.py
+++ b/cabd-database/chyf/nhn_data_processing/nhn_data_qa.py
@@ -16,6 +16,8 @@ def run_qa(conn, workunit):
           message varchar,
           geometry geometry(POINT)
         );
+
+        alter table {workingSchema}.qaerrors owner to chyf;
         
         truncate {workingSchema}.qaerrors;
     """


### PR DESCRIPTION
**Change:** nhn_data_load.py and nhn_data_qa.py have been updated to change the schema and table owners to the chyf role when importing new workunits to Postgres.

**Reason for change:** By default, schemas and tables have been owned by the individual who imported these into the DB. Since we are only completing pre-processing at this time while we await potential data model changes from NRCan (i.e., not working in the fpinput/output schemas), these tables need to be accessible to each person processing hydro networks to compare any conflicts and align features along workunit boundaries.

