### PR TITLE
Clear any existing data from fpoutput upon load

### DIFF
--- a/cabd-database/chyf/nhn_data_processing/nhn_2_fpprocessing.py
+++ b/cabd-database/chyf/nhn_data_processing/nhn_2_fpprocessing.py
@@ -14,6 +14,7 @@ dbPassword = sys.argv[5]
 workunit = sys.argv[6].upper()
 fromschema = "nhn" + workunit.lower()
 toschema = "fpinput"
+outschema = "fpoutput"
 srid = 4617
 
 def log(message):
@@ -86,6 +87,11 @@ def copytonhnraw(conn):
     delete from {toschema}.shoreline where aoi_id in (select id from {toschema}.aoi where name = '{workunit}');
     delete from {toschema}.terminal_node where aoi_id in (select id from {toschema}.aoi where name = '{workunit}');
     delete from {toschema}.aoi where name = '{workunit}';
+    delete from {outschema}.eflowpath where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
+    delete from {outschema}.ecatchment where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
+    delete from {outschema}.shoreline where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
+    delete from {outschema}.terminal_node where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
+    delete from {outschema}.aoi where name = '{workunit}';
     
     insert into {toschema}.aoi (id, name, geometry) 
     select id, '{workunit}', st_transform(geometry, {srid}) from {fromschema}.aoi;

--- a/cabd-database/chyf/nhn_data_processing/nhn_2_fpprocessing.py
+++ b/cabd-database/chyf/nhn_data_processing/nhn_2_fpprocessing.py
@@ -91,6 +91,9 @@ def copytonhnraw(conn):
     delete from {outschema}.ecatchment where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
     delete from {outschema}.shoreline where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
     delete from {outschema}.terminal_node where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
+    delete from {outschema}.construction_points where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');
+    delete from {outschema}.errors where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');     
+    delete from {outschema}.feature_names where aoi_id in (select id from {outschema}.aoi where name = '{workunit}');         
     delete from {outschema}.aoi where name = '{workunit}';
     
     insert into {toschema}.aoi (id, name, geometry) 


### PR DESCRIPTION
This change clears any existing data from fpoutput when data is copied from its individual processing schema to the schemas used for running the flowpath tools.

This fixes an issue where datasets that had been run through the flowpath tools could be duplicated in fpoutput if the dataset was reloaded to an individual processing schema and re-processed. Since the reloaded dataset had a different `aoi_id` than the previous one run through the flowpath tools, it was not recognized as being the same dataset.

There is also a new unique constraint on the `name` field in fpinput.aoi and fpoutput.aoi that will notify users if there is already data for that AOI present.