### PR TITLE
add support for bbox to feature metadata 

### DIFF
--- a/cabd-web/src/main/java/org/refractions/cabd/model/FeatureTypeListValue.java
+++ b/cabd-web/src/main/java/org/refractions/cabd/model/FeatureTypeListValue.java
@@ -25,12 +25,25 @@ public class FeatureTypeListValue extends NamedDescriptionItem implements Compar
 
 	private Object value;
 	
+	private double[] bbox;
 	
 	public FeatureTypeListValue(Object value, String name_en, 
 			String name_fr, String description_en, String description_fr) {
 		super(name_en, name_fr, description_en, description_fr);
-		
+		this.bbox = null;
 		this.value = value;
+	}
+	
+	public FeatureTypeListValue(Object value, String name_en, 
+			String name_fr, String description_en, String description_fr,
+			Double minx, Double miny, Double maxx, Double maxy) {
+		super(name_en, name_fr, description_en, description_fr);
+		this.bbox = new double[]{minx, miny, maxx, maxy};
+		this.value = value;
+	}
+	
+	public double[] getBbox() {
+		return bbox;
 	}
 	
 	public Object getValue() {

--- a/cabd-web/src/main/java/org/refractions/cabd/serializers/AbstractFeatureTypeJsonSerializer.java
+++ b/cabd-web/src/main/java/org/refractions/cabd/serializers/AbstractFeatureTypeJsonSerializer.java
@@ -72,6 +72,20 @@ public abstract class AbstractFeatureTypeJsonSerializer<T> extends JsonSerialize
 					if(listitem.getDescription() != null) {
 						gen.writeStringField("description", listitem.getDescription());
 					}
+					if (listitem.getBbox() != null) {
+						gen.writeFieldName("bbox");
+						gen.writeStartArray();
+						gen.writeStartArray();
+						gen.writeNumber(listitem.getBbox()[0]);
+						gen.writeNumber(listitem.getBbox()[1]);
+						gen.writeEndArray();
+						gen.writeStartArray();
+						gen.writeNumber(listitem.getBbox()[2]);
+						gen.writeNumber(listitem.getBbox()[3]);
+						gen.writeEndArray();
+						gen.writeEndArray();
+						
+					}
 					gen.writeEndObject();
 				}
 				


### PR DESCRIPTION
The request was to add bbox to for nhn work units. Implemented as a field in the metadata table that identifies the geometry column (in applicable) and adds the bbox from that column to the metadata output.