### PR TITLE
bug fixes for community data processing

### DIFF
--- a/cabd-database/cabd/cabd.updates.05152024.mobileapp.sql
+++ b/cabd-database/cabd/cabd.updates.05152024.mobileapp.sql
@@ -84,3 +84,27 @@ alter table dams.dams_community_staging add CONSTRAINT status_value_ch CHECK (st
 alter table stream_crossings.stream_crossings_community_staging drop CONSTRAINT status_value_ch; 
 alter table stream_crossings.stream_crossings_community_staging add CONSTRAINT status_value_ch CHECK (status IN ('NEW', 'REJECTED', 'REVIEWED'));
  
+ 
+ 
+ -- ** bug fixes ** --
+ 
+alter table cabd.vector_tile_cache alter column key type varchar(128);
+
+
+CREATE OR REPLACE VIEW cabd.updates_pending
+AS SELECT DISTINCT dam_updates.cabd_id
+   FROM cabd.dam_updates
+UNION ALL
+ SELECT DISTINCT fishway_updates.cabd_id
+   FROM cabd.fishway_updates
+UNION ALL
+ SELECT DISTINCT waterfall_updates.cabd_id
+   FROM cabd.waterfall_updates
+UNION ALL
+ SELECT DISTINCT dams_community_staging.cabd_id
+   FROM dams.dams_community_staging
+  WHERE dams_community_staging.status::text = 'NEW'::text
+UNION ALL
+ SELECT DISTINCT stream_crossings_community_staging.cabd_id
+   FROM stream_crossings.stream_crossings_community_staging
+  WHERE stream_crossings_community_staging.status::text = 'NEW'::text;

--- a/cabd-web/src/main/java/org/refractions/cabd/controllers/CommunityProcessor.java
+++ b/cabd-web/src/main/java/org/refractions/cabd/controllers/CommunityProcessor.java
@@ -138,7 +138,7 @@ public class CommunityProcessor {
 			
 			FeatureType featuretype = typeManager.getFeatureType(feature.getFeatureType());
 			if (featuretype == null) {
-				data.getWarnings().add(MessageFormat.format("Feature {0): Feature type {1} not found. Community data not processed.", feature.getIndex(), feature.getFeatureType()));
+				data.getWarnings().add(MessageFormat.format("Feature {0}: Feature type {1} not found. Community data not processed.", feature.getIndex(), feature.getFeatureType()));
 				continue;
 			}
 			


### PR DESCRIPTION
Fixed a bug with error messages.
Increased the size of the vector tile cache key field - log files had a number of errors related to it being too small
Fixed the pending_updates view to contain distinct feature ids only to prevent duplicate features from being returned in the feature views.