### PR TITLE
bug: change in/notin filter to use ; instead of , 

### DIFF
--- a/cabd-web/src/main/java/org/refractions/cabd/dao/filter/Filter.java
+++ b/cabd-web/src/main/java/org/refractions/cabd/dao/filter/Filter.java
@@ -159,7 +159,7 @@ public class Filter {
 		Operator op = Operator.findOperator(filter.substring(first + 1, second));
 		String[] values = null;
 		if (op == Operator.IN || op == Operator.NOTIN) {
-			values = filter.substring(second+1).split(",");
+			values = filter.substring(second+1).split(";");
 		}else {
 			values = new String[] {filter.substring(second + 1)};
 		}


### PR DESCRIPTION
Using comma for list in query parameters was problematic. These were parsed as separate filters not one filter with multiple items. 

#108 